### PR TITLE
Fix path parsing bug

### DIFF
--- a/src/main/kotlin/work/jeong/murry/ktor/features/EasySpaFeature.kt
+++ b/src/main/kotlin/work/jeong/murry/ktor/features/EasySpaFeature.kt
@@ -32,6 +32,7 @@ import io.ktor.http.content.default
 import io.ktor.http.content.files
 import io.ktor.http.content.static
 import io.ktor.http.content.staticRootFolder
+import io.ktor.request.path
 import io.ktor.request.uri
 import io.ktor.response.respondFile
 import io.ktor.response.respondRedirect
@@ -80,7 +81,7 @@ class EasySpaFeature(configuration: Configuration) {
 
             pipeline.intercept(ApplicationCallPipeline.Features) {
                 if (!call.request.uri.startsWith(configuration.apiUrl)) {
-                    val path = call.request.uri.split("/")
+                    val path = call.request.path().split("/")
                     if (path.last().matches(Regex("[\\S]+\\.[\\S]+"))) {
                         // NOTE: resource files like *.css, *.js and so on
                         val urlPathString = String.joinUrlPath(configuration.staticRootDocs, path.subList(1, path.lastIndex))


### PR DESCRIPTION
## Summary
- fix file lookup when query params are present by using request.path()

## Testing
- `mvn -q -DskipTests=false test` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_e_688719dbb9688322901648de47a9f21f