### PR TITLE
Fix URI handling in EasySpaFeature

### DIFF
--- a/src/main/kotlin/work/jeong/murry/ktor/features/EasySpaFeature.kt
+++ b/src/main/kotlin/work/jeong/murry/ktor/features/EasySpaFeature.kt
@@ -81,7 +81,8 @@ class EasySpaFeature(configuration: Configuration) {
 
             pipeline.intercept(ApplicationCallPipeline.Features) {
                 if (!call.request.uri.startsWith(configuration.apiUrl)) {
-                    val path = call.request.path().split("/")
+                    val requestPath = call.request.uri.substringBefore('?')
+                    val path = requestPath.split("/")
                     if (path.last().matches(Regex("[\\S]+\\.[\\S]+"))) {
                         // NOTE: resource files like *.css, *.js and so on
                         val urlPathString = String.joinUrlPath(configuration.staticRootDocs, path.subList(1, path.lastIndex))


### PR DESCRIPTION
## Summary
- sanitize request URI before splitting it into path segments

## Testing
- `mvn -q test` *(fails: nexus-staging-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68871b0cd8e88322bdcdcf54a3d4d6a9